### PR TITLE
SendKey/SendSignal fixes

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -490,7 +490,9 @@ target_link_libraries(lime_core PUBLIC lime_common PRIVATE audio_core network vi
 target_link_libraries(lime_core PRIVATE Boost::boost Boost::serialization Boost::iostreams httplib)
 target_link_libraries(lime_core PUBLIC dds-ktx PRIVATE cryptopp fmt lodepng open_source_archives)
 
-target_link_libraries(lime_core PUBLIC input_common)
+if (NOT ANDROID)
+    target_link_libraries(lime_core PUBLIC input_common)
+endif()
 
 if (ENABLE_WEB_SERVICE)
     target_link_libraries(lime_core PRIVATE web_service)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -490,6 +490,8 @@ target_link_libraries(lime_core PUBLIC lime_common PRIVATE audio_core network vi
 target_link_libraries(lime_core PRIVATE Boost::boost Boost::serialization Boost::iostreams httplib)
 target_link_libraries(lime_core PUBLIC dds-ktx PRIVATE cryptopp fmt lodepng open_source_archives)
 
+target_link_libraries(lime_core PUBLIC input_common)
+
 if (ENABLE_WEB_SERVICE)
     target_link_libraries(lime_core PRIVATE web_service)
 endif()

--- a/src/core/rpc/rpc_server.h
+++ b/src/core/rpc/rpc_server.h
@@ -29,8 +29,12 @@ public:
 private:
     void HandleReadMemory(Packet& packet, u32 address, u32 data_size);
     void HandleWriteMemory(Packet& packet, u32 address, std::span<const u8> data);
+
+#ifndef ANDROID
     void HandleSendKey(Packet& packet, u32 key_code, u8 state);
     void HandleSendSignal(Packet& packet, u32 signal_code, u32 signal_parameter);
+#endif
+
     bool ValidatePacket(const PacketHeader& packet_header);
     void HandleSingleRequest(std::unique_ptr<Packet> request);
     void HandleRequestsLoop(std::stop_token stop_token);


### PR DESCRIPTION
This should help the PR pass the build checks. In summary:
* Link `input_common` library into `lime_core`.
* Add Android guard rails as `input_common` relies on SDL but Android is not built with SDL support.
* Apply clang-format-18 formatting.